### PR TITLE
Make needle case-insensitive

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -204,7 +204,7 @@ filter searchTerm items =
 
 contains : String -> Item -> Bool
 contains searchTerm =
-    String.contains searchTerm << String.toLower << .name
+    String.contains (String.toLower searchTerm) << String.toLower << .name
 
 
 itemsDecoder : D.Decoder Items

--- a/tests/MainTest.elm
+++ b/tests/MainTest.elm
@@ -41,6 +41,16 @@ filterItems =
                         |> Main.filter (Just "re")
                         |> List.length
                         |> Expect.equal 2
+            , test "that filter is case insensitive wrt to needle" <|
+                \_ ->
+                    let
+                        items =
+                            [ Item "Response", Item "rest" ]
+                    in
+                    items
+                        |> Main.filter (Just "Re")
+                        |> List.length
+                        |> Expect.equal 2
             ]
         , describe "contains tests"
             [ test "should contain with empty needle" <|


### PR DESCRIPTION
Before searching Result would not match en entry of 'result' because the
needle was case-sensitive. This has now been changed.

Fixes #11
